### PR TITLE
Use "==" instead of "="

### DIFF
--- a/Minify/MinifyTags.php
+++ b/Minify/MinifyTags.php
@@ -67,10 +67,10 @@ class MinifyTags extends Tags
         $minifiedPath = "$this->basePath$this->publicPath/$this->output/$hash.$type";
         file_put_contents($minifiedPath, '');
 
-        if ($type = 'css') {
+        if ($type == 'css') {
             $minifier = new Minify\CSS($sourcePath);
             $minifier->minify($minifiedPath);
-        } elseif ($type = 'js') {
+        } elseif ($type == 'js') {
             $minifier = new Minify\JS($sourcePath);
             $minifier->minify($minifiedPath);
         }


### PR DESCRIPTION
---
title: "Use correct comparison operator for file-type"
assignees: damcclean
---

<!--
    Please make sure to fill in all the fields, if appropriate.
    This helps us understand your pull request.
-->

**Description of changes made in this pull request**
Changed the if block to use "==" instead of "=", which was causing `.js` files to be appended with `.css` rather than `.js`.
```php
if ($type = 'css')
```
sets the $type to 'css'. This is undesirable.